### PR TITLE
add cis benchmark action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,7 @@
+cis-benchmark:
+  description: CIS Kubernetes Benchmark
+  params:
+    mode:
+      type: string
+      default: 'run'
+      description: Action mode. Defauls to 'run'.

--- a/actions/cis-benchmark
+++ b/actions/cis-benchmark
@@ -1,0 +1,120 @@
+#!/usr/local/sbin/charm-env python3
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+
+from pathlib import Path
+from shutil import which
+
+from charmhelpers.core import hookenv
+from charmhelpers.fetch.giturl import GitUrlFetchHandler
+from charms.layer import snap
+from charms.reactive import is_flag_set
+
+
+BENCH_CMD = '/usr/local/bin/kube-bench'
+BENCH_PKG = 'github.com/aquasecurity/kube-bench'
+
+
+def fail(msg):
+    hookenv.action_fail(msg)
+    sys.exit()
+
+
+def install():
+    '''Install kube-bench and related configuration.
+
+    Install go if needed. Pull, build, and setup snap-based benchmark
+    configuration.
+    '''
+    go_bin = which('go')
+    if not go_bin:
+        go_bin = '/snap/bin/go'
+        snap.install('go', channel='stable', classic=True)
+
+    go_cache = os.getenv('GOCACHE', '/var/snap/go/common/cache')
+    go_path = os.getenv('GOPATH', '/var/snap/go/common')
+    env = os.environ.copy()
+    env['GOCACHE'] = go_cache
+    env['GOPATH'] = go_path
+    Path(go_path).mkdir(parents=True, exist_ok=True)
+
+    go_cmd = ('{bin} get {pkg} '
+              'github.com/golang/dep/cmd/dep'.format(bin=go_bin, pkg=BENCH_PKG))
+    try:
+        subprocess.check_call(shlex.split(go_cmd), cwd=go_path, env=env)
+    except subprocess.CalledProcessError:
+        fail('Failed to run: {}'.format(go_cmd))
+
+    go_cmd = ('{bin} build -o {out} {base}/src/{pkg}'.format(
+        bin=go_bin, out=BENCH_CMD, base=go_path, pkg=BENCH_PKG))
+    try:
+        subprocess.check_call(shlex.split(go_cmd), cwd=go_path, env=env)
+    except subprocess.CalledProcessError:
+        fail('Failed to run: {}'.format(go_cmd))
+
+    cfg_dir = '{bin}/src/{pkg}/cfg-ck'.format(bin=go_path, pkg=BENCH_PKG)
+    GitUrlFetchHandler().clone('https://github.com/charmed-kubernetes/kube-bench-config.git',
+                               dest=cfg_dir)
+
+
+def run():
+    app = hookenv.charm_name() or ''
+    version = '1.13-snap-k8s'
+    if 'master' in app:
+        app = 'master'
+    elif 'worker' in app:
+        app = 'node'
+    elif 'etcd' in app:
+        app = 'etcd'
+        version = '1.13-snap-etcd'
+
+    go_path = os.getenv('GOPATH', '/var/snap/go/common')
+    res_path = '/home/ubuntu/kube-bench-results'
+    verbose_cmd = ('{bin} --config-dir {base}/src/{pkg}/cfg-ck --version {ver} '
+                   '{app}'.format(bin=BENCH_CMD, base=go_path, pkg=BENCH_PKG, ver=version, app=app))
+    summary_cmd = ('{bin} --config-dir {base}/src/{pkg}/cfg-ck --version {ver} --noremediations '
+                   '{app}'.format(bin=BENCH_CMD, base=go_path, pkg=BENCH_PKG, ver=version, app=app))
+
+    # store full results for future operator consumption
+    Path(res_path).mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode='w+b', prefix='kube-bench-',
+                                     dir=res_path, delete=False) as res_file:
+        try:
+            subprocess.call(shlex.split(verbose_cmd), stdout=res_file)
+        except subprocess.CalledProcessError:
+            fail('Failed to run: {}'.format(verbose_cmd))
+        else:
+            # send fetch command to action output
+            Path(res_file.name).chmod(0o644)
+            fetch_cmd = 'juju scp {unit}:{file} `pwd`'.format(unit=hookenv.local_unit(),
+                                                              file=res_file.name)
+            hookenv.action_set({'cmd': verbose_cmd, 'fetch-cmd': fetch_cmd})
+
+    # send summary results to action output
+    try:
+        out = subprocess.check_output(shlex.split(summary_cmd), universal_newlines=True)
+    except subprocess.CalledProcessError:
+        fail('Failed to run: {}'.format(summary_cmd))
+    else:
+        # set action output
+        hookenv.action_set({'summary': out})
+
+
+if __name__ == '__main__':
+    if not (is_flag_set('kubernetes-master.snaps.installed') or
+            is_flag_set('kubernetes-worker.snaps.installed')):
+        msg = 'Kubernetes snaps are not installed'
+        fail(msg)
+
+    mode = hookenv.action_get('mode') or ''
+    if mode not in ['apply', 'run']:
+        msg = 'Invalid mode parameter: {}'.format(mode)
+        fail(msg)
+
+    if mode == 'run':
+        if not Path(BENCH_CMD).exists():
+            install()
+        run()


### PR DESCRIPTION
Add an action to run the CIS K8s benchmark on k8s master and worker units.  Fixes:

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841262

Summary data is provided in the action output with a `fetch_cmd` that allows users to download the full benchmark log:
```bash
$ juju run-action --wait kubernetes-worker/0 cis-benchmark
results:
  cmd: /usr/local/bin/kube-bench --config-dir /var/snap/go/common/src/github.com/aquasecurity/kube-bench/cfg-ck
    --version 1.13-snap-k8s node
  fetch-cmd: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/kube-bench-ezoa5zk6
    `pwd`
  summary: |
    [INFO] 2 Worker Node Security Configuration
    [INFO] 2.1 Kubelet
    [FAIL] 2.1.1 Ensure that the --anonymous-auth argument is set to false (Scored)
    [FAIL] 2.1.2 Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)
    [FAIL] 2.1.3 Ensure that the --client-ca-file argument is set as appropriate (Scored)
    [FAIL] 2.1.4 Ensure that the --read-only-port argument is set to 0 (Scored)
    [PASS] 2.1.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)
    [FAIL] 2.1.6 Ensure that the --protect-kernel-defaults argument is set to true (Scored)
    [PASS] 2.1.7 Ensure that the --make-iptables-util-chains argument is set to true (Scored)
    [PASS] 2.1.8 Ensure that the --hostname-override argument is not set (Scored)
    [FAIL] 2.1.9 Ensure that the --event-qps argument is set to 0 (Scored)
    [FAIL] 2.1.10 Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)
    [INFO] 2.1.11 [DEPRECATED] Ensure that the --cadvisor-port argument is set to 0 (Not Scored)
    [FAIL] 2.1.12 Ensure that the --rotate-certificates argument is not set to false (Scored)
    [FAIL] 2.1.13 Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)
    [WARN] 2.1.14 Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Not Scored)
    [INFO] 2.2 Configuration Files
    [PASS] 2.2.1 Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)
    [PASS] 2.2.2 Ensure that the kubelet.conf file ownership is set to root:root (Scored)
    [PASS] 2.2.3 Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)
    [PASS] 2.2.4 Ensure that the kubelet service file ownership is set to root:root (Scored)
    [PASS] 2.2.5 Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive (Scored)
    [PASS] 2.2.6 Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)
    [WARN] 2.2.7 Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)
    [PASS] 2.2.8 Ensure that the client certificate authorities file ownership is set to root:root (Scored)
    [PASS] 2.2.9 Ensure that the kubelet configuration file ownership is set to root:root (Scored)
    [PASS] 2.2.10 Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)

    == Summary ==
    12 checks PASS
    9 checks FAIL
    2 checks WARN
    1 checks INFO
status: completed
timing:
  completed: 2019-09-18 06:59:24 +0000 UTC
  enqueued: 2019-09-18 06:59:20 +0000 UTC
  started: 2019-09-18 06:59:23 +0000 UTC
```