### PR TITLE
include cis-benchmark for k8s master/worker charms

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,5 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
+- 'layer:cis-benchmark'
 - 'layer:kubernetes-common'
 - 'interface:container-runtime'


### PR DESCRIPTION
Include the cis-benchmark layer for k8s master/worker charms.  This layer brings in the `cis-benchmark` action for use in reporting/remediating benchmark failures.

Partially fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841262

Depends on https://github.com/juju/layer-index/pull/98