### PR TITLE
add layer-coordinator to roll snap refreshes

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,5 +1,6 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
 - 'layer:cis-benchmark'
+- 'layer:coordinator'
 - 'layer:kubernetes-common'
 - 'interface:container-runtime'


### PR DESCRIPTION
When masters or workers join a cohort, we do so one unit at a time.  We need layer-coordinator for that.

Depends on:
https://github.com/charmed-kubernetes/jenkins/pull/546