### PR TITLE
update default sysctl config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   sysctl:
     type: string
-    default: "{ net.ipv4.conf.all.forwarding : 1, net.ipv4.neigh.default.gc_thresh1 : 128, net.ipv4.neigh.default.gc_thresh2 : 28672, net.ipv4.neigh.default.gc_thresh3 : 32768, net.ipv6.neigh.default.gc_thresh1 : 128, net.ipv6.neigh.default.gc_thresh2 : 28672, net.ipv6.neigh.default.gc_thresh3 : 32768, fs.inotify.max_user_instances : 8192, fs.inotify.max_user_watches: 1048576 }"
+    default: "{ net.ipv4.conf.all.forwarding : 1, net.ipv4.neigh.default.gc_thresh1 : 128, net.ipv4.neigh.default.gc_thresh2 : 28672, net.ipv4.neigh.default.gc_thresh3 : 32768, net.ipv6.neigh.default.gc_thresh1 : 128, net.ipv6.neigh.default.gc_thresh2 : 28672, net.ipv6.neigh.default.gc_thresh3 : 32768, fs.inotify.max_user_instances : 8192, fs.inotify.max_user_watches : 1048576, kernel.panic : 10, kernel.panic_on_oops: 1, vm.overcommit_memory : 1 }"
     description: |
       YAML formatted associative array of sysctl values, e.g.:
       '{kernel.pid_max : 4194303 }'. Note that kube-proxy handles


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1887810

Adjust the default config so we can enable `protect-kernel-defaults` on k8s-workers to pass the CIS K8s benchmark.  Without this change, kubelets would fail to start with:

```bash
Jul 14 19:50:29 ip-172-31-29-43 kubelet.daemon[23652]: F0714 19:50:29.335028   23652 kubelet.go:1383] Failed to start ContainerManager [invalid kernel flag: vm/overcommit_memory, expected value: 1, actual value: 0, invalid kernel flag: kernel/panic, expected value: 10, actual value: 0, invalid kernel flag: kernel/panic_on_oops, expected 
Jul 14 19:50:29 ip-172-31-29-43 systemd[1]: snap.kubelet.daemon.service: Main process exited, code=exited, status=255/n/a
```

From https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/:
```
--protect-kernel-defaults
Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
```

And from https://github.com/kubernetes/kubernetes/blob/release-1.19/pkg/util/sysctl/sysctl.go#L49-L56, we can see what values k8s expects for these kernel tunables.