### PR TITLE
Add CNI resources and install_cni_plugins handler

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,3 +2,16 @@ provides:
   container-runtime:
     interface: container-runtime
     scope: container
+resources:
+  cni-amd64:
+    type: file
+    filename: cni.tgz
+    description: CNI plugins for amd64
+  cni-arm64:
+    type: file
+    filename: cni.tgz
+    description: CNI plugins for arm64
+  cni-s390x:
+    type: file
+    filename: cni.tgz
+    description: CNI plugins for s390x


### PR DESCRIPTION
The CNI resources were previously handled by kubernetes-worker. We want them on kubernetes-master too, so, move the resource definitions and code to the shared base layer.

This is needed for kubelets on masters.