### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: woke
-        uses: canonical-web-and-design/inclusive-naming@main
+        uses: canonical-web-and-design/inclusive-naming@7aa0f7a606f182bd03a7adb28e0d710216101ca5 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
@@ -21,9 +21,9 @@ jobs:
         python: [3.6, 3.7, 3.8, 3.9]
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install Dependencies


### PR DESCRIPTION
Pin all GitHub Actions to their commit SHAs to improve supply chain security.

This prevents:
- Compromised tags from injecting malicious code
- Unexpected behavior from mutable references
- Supply chain attacks via action tag manipulation